### PR TITLE
Remove variable metrics_server_config from api_server.py

### DIFF
--- a/jetstream/entrypoints/http/api_server.py
+++ b/jetstream/entrypoints/http/api_server.py
@@ -100,21 +100,15 @@ def server(argv: Sequence[str]):
   print(f"server_config: {server_config}")
   del argv
 
-  metrics_server_config: config_lib.MetricsServerConfig | None = None
-  # Setup Prometheus server
-  metrics_collector: JetstreamMetricsCollector = None
   if flags.FLAGS.prometheus_port != 0:
-    metrics_server_config = config_lib.MetricsServerConfig(
-        port=flags.FLAGS.prometheus_port
-    )
     logging.info(
-        "Starting Prometheus server on port %d", metrics_server_config.port
+        "Starting Prometheus server on port %d", flags.FLAGS.prometheus_port
     )
-    start_http_server(metrics_server_config.port)
+    start_http_server(flags.FLAGS.prometheus_port)
     metrics_collector = JetstreamMetricsCollector()
   else:
     logging.info(
-        "Not starting Prometheus server: --prometheus_port flag not set"
+        "Not starting Prometheus server as --prometheus_port flag not set"
     )
 
   global llm_orchestrator


### PR DESCRIPTION
It seems lexically, the variable metrics_server_config is not needed. Hence this propose to remove it. Please let me know if my coding reading effort went wrong. Thanks!