### PR TITLE
[Benchmark Metrics] Add reporting in benchmark for (1) TTST(time-to-second-token) (2) req complete rate time series (3) output token throughput rate time series

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -71,6 +71,7 @@ import os
 
 
 import grpc
+from benchmarks.metrics import EventMetric, CounterMetric
 from jetstream.core.proto import jetstream_pb2
 from jetstream.core.proto import jetstream_pb2_grpc
 from jetstream.engine.token_utils import load_vocab
@@ -152,12 +153,10 @@ class BenchmarkMetrics:
   request_throughput: float
   input_throughput: float
   output_throughput: float
-  mean_ttft_ms: float
-  median_ttft_ms: float
-  p99_ttft_ms: float
-  mean_tpot_ms: float
-  median_tpot_ms: float
-  p99_tpot_ms: float
+
+  ttft: EventMetric  # Time-to-first-token
+  ttst: EventMetric  # Time-to-second-token
+  tpot: EventMetric  # Time-per-output-token
 
 
 @dataclass
@@ -171,24 +170,37 @@ class InputRequest:
 
 @dataclass
 class RequestFuncOutput:
+  """Data class to store the response of a request."""
+
   input_request: Optional[InputRequest] = None
-  generated_token_list: list[str] = field(default_factory=list)
+  generated_token_list: list[int] = field(default_factory=list)
   generated_text: str = ""
   success: bool = False
-  latency: float = 0
-  ttft: float = 0
+  latency_sec: float = 0
+  ttft_sec: float = 0
+  ttst_sec: float = 0
   prompt_len: int = 0
 
   # Flatten the structure and return only the necessary results
   def to_dict(self):
+    if self.input_request:
+      prompt = self.input_request.prompt
+      original_output = self.input_request.output
+      sample_idx = self.input_request.sample_idx
+    else:
+      prompt = None
+      original_output = None
+      sample_idx = None
     return {
-        "prompt": self.input_request.prompt,
-        "original_output": self.input_request.output,
+        "prompt": prompt,
+        "original_output": original_output,
         "generated_text": self.generated_text,
         "success": self.success,
-        "latency": self.latency,
+        "latency_sec": self.latency_sec,
+        "ttft_sec": self.ttft_sec,
+        "ttst_sec": self.ttst_sec,
         "prompt_len": self.prompt_len,
-        "sample_idx": self.input_request.sample_idx,
+        "sample_idx": sample_idx,
     }
 
 
@@ -411,11 +423,13 @@ def calculate_metrics(
   total_output = 0
   total_input = 0
   completed = 0
-  per_token_latencies = []
-  ttfts = []
+  ttft = EventMetric("ttft", "Time-to-first-token", "ms")
+  ttst = EventMetric("ttst", "Time-to-second-token", "ms")
+  per_out_token_lat = EventMetric("TPOT", "Time-per-output-token", "ms")
   output_sizes = []
   for i in range(len(outputs)):
     if outputs[i].success:
+      completed += 1
       output_len = len(
           outputs[i].generated_token_list
           if tokenizer != "test"
@@ -430,9 +444,9 @@ def calculate_metrics(
              output: {outputs[i]}"""
         )
         continue
-      per_token_latencies.append(outputs[i].latency / output_len)
-      ttfts.append(outputs[i].ttft)
-      completed += 1
+      ttft.record(outputs[i].ttft_sec * 1000)
+      ttst.record(outputs[i].ttst_sec * 1000)
+      per_out_token_lat.record(outputs[i].latency_sec / output_len * 1000)
 
   print("Mean output size:", float(np.mean(output_sizes)))
   print("Median output size:", float(np.median(output_sizes)))
@@ -445,12 +459,9 @@ def calculate_metrics(
       request_throughput=completed / dur_s,
       input_throughput=total_input / dur_s,
       output_throughput=total_output / dur_s,
-      mean_ttft_ms=float(np.mean(ttfts) * 1000),
-      median_ttft_ms=float(np.median(ttfts) * 1000),
-      p99_ttft_ms=float(np.percentile(ttfts, 99) * 1000),
-      mean_tpot_ms=float(np.mean(per_token_latencies) * 1000),
-      median_tpot_ms=float(np.median(per_token_latencies) * 1000),
-      p99_tpot_ms=float(np.percentile(per_token_latencies, 99) * 1000),
+      ttft=ttft,
+      ttst=ttst,
+      tpot=per_out_token_lat,
   )
 
   return metrics
@@ -461,30 +472,33 @@ async def grpc_async_request(
     request: Any,
     prefill_quota: AsyncCounter,
     active_req_quota: AsyncCounter,
-) -> tuple[list[str], float, float]:
+    out_token_cnt: CounterMetric,
+) -> tuple[list[int], float, float, float]:
   """Send grpc synchronous request since the current grpc server is sync."""
   options = [("grpc.keepalive_timeout_ms", 10000)]
   async with grpc.aio.insecure_channel(api_url, options=options) as channel:
     stub = jetstream_pb2_grpc.OrchestratorStub(channel)
-    ttft = 0
-    token_list = []
     request_start_time = time.perf_counter()
     response = stub.Decode(request)
+    token_list = []
+    ttft = 0
+    ttst = 0
+    stream_resp_cnt = 0
     async for resp in response:
-      if ttft == 0:
+      stream_resp_cnt += 1
+      if stream_resp_cnt == 1:
         await prefill_quota.inc()
-
         ttft = time.perf_counter() - request_start_time
         if ttft > 2.0:
-          print(
-              datetime.now(),
-              f"slow TTFT {ttft:.2f}",
-              prefill_quota.value(),
-          )
-      token_list.extend(resp.stream_content.samples[0].token_ids)
+          print(datetime.now(), f"slow TTFT {ttft:.2f}", prefill_quota.value())
+      elif stream_resp_cnt == 2:
+        ttst = time.perf_counter() - request_start_time
+      resp_tokens = resp.stream_content.samples[0].token_ids
+      token_list.extend(resp_tokens)
+      out_token_cnt.increment(len(resp_tokens))
     await active_req_quota.inc()
-    latency = time.perf_counter() - request_start_time
-    return token_list, ttft, latency
+    req_latency = time.perf_counter() - request_start_time
+    return token_list, ttft, ttst, req_latency
 
 
 async def send_request(
@@ -493,12 +507,15 @@ async def send_request(
     input_request: InputRequest,
     prefill_quota: AsyncCounter,
     active_req_quota: AsyncCounter,
+    req_complete_cnt: CounterMetric,
+    out_token_cnt: CounterMetric,
     pbar: tqdm,
 ) -> RequestFuncOutput:
   """Send the request to JetStream server."""
-
-  # Tokenization on client side following MLPerf standard.
+  # Tokenize on client side following MLPerf standard.
   token_ids = tokenizer.encode(input_request.prompt)
+
+  # Send the request
   request = jetstream_pb2.DecodeRequest(
       token_content=jetstream_pb2.DecodeRequest.TokenContent(
           token_ids=token_ids
@@ -508,17 +525,25 @@ async def send_request(
           start_time=time.perf_counter()
       ),
   )
+  out_tokens, ttft_sec, ttst_sec, latency_sec = await grpc_async_request(
+      api_url,
+      request,
+      prefill_quota,
+      active_req_quota,
+      out_token_cnt,
+  )
+  req_complete_cnt.increment()
+
+  # Collect per-request output and metrics.
   output = RequestFuncOutput()
   output.input_request = input_request
   output.prompt_len = input_request.prompt_len
-  generated_token_list, ttft, latency = await grpc_async_request(
-      api_url, request, prefill_quota, active_req_quota
-  )
-  output.ttft = ttft
-  output.latency = latency
-  output.generated_token_list = generated_token_list
+  output.ttft_sec = ttft_sec
+  output.ttst_sec = ttst_sec
+  output.latency_sec = latency_sec
+  output.generated_token_list = out_tokens
   # generated_token_list is a list of token ids, decode it to generated_text.
-  output.generated_text = tokenizer.decode(generated_token_list)
+  output.generated_text = tokenizer.decode(out_tokens)
   output.success = True
   if pbar:
     pbar.postfix = (
@@ -539,18 +564,39 @@ async def benchmark(
     disable_tqdm: bool,
     prefill_quota: AsyncCounter,
     active_req_quota: AsyncCounter,
-):
-  """Benchmark the online serving performance."""
+    is_warmup: bool = False,
+) -> tuple[dict[str, float | int], list[RequestFuncOutput]]:
+  """Benchmark the online serving performance.
+
+  Args:
+    api_url: URL (e.g. host:port) of the JetStream server to send requests to.
+    tokenizer: The tokenizer used to convert texts into tokens that will be set
+      in requests.
+    input_requests: A list of requests to send.
+    request_rate: The number of requests to send per second.
+    disable_tqdm: Whether progress bar should be disabled or not.
+    prefill_quota: Quota for limiting pending prefill operations.
+    active_req_quota: Quota for limiting inflight requests.
+    is_warmup: Whether this run is to warm up the server.
+
+  Return:
+    A tuple containing the performance statistics for all requests and a list
+    of responses from the executed requests.
+  """
+  print(f"Benchmarking with a total number of {len(input_requests)} requests")
+  print(f"Benchmarking with request rate of {request_rate}")
   pbar = None if disable_tqdm else tqdm(total=len(input_requests))
+  req_complete_cnt = CounterMetric(
+      "ReqCompleteCount", "Request Completion Counter"
+  )
+  out_token_cnt = CounterMetric("OutTokenCount", "OutToken Counter")
 
-  print(f"Traffic request rate: {request_rate}")
-
-  benchmark_start_time = time.perf_counter()
+  # Run benchmarking
   tasks = []
+  benchmark_start_time = time.perf_counter()
   async for request in get_request(input_requests, request_rate):
     await prefill_quota.dec()
     await active_req_quota.dec()
-
     tasks.append(
         asyncio.create_task(
             send_request(
@@ -559,54 +605,69 @@ async def benchmark(
                 input_request=request,
                 prefill_quota=prefill_quota,
                 active_req_quota=active_req_quota,
+                req_complete_cnt=req_complete_cnt,
+                out_token_cnt=out_token_cnt,
                 pbar=pbar,
             )
         )
     )
   outputs = await asyncio.gather(*tasks)
-
-  if not disable_tqdm and pbar:
+  if pbar is not None:
     pbar.close()
 
-  benchmark_duration = time.perf_counter() - benchmark_start_time
+  # Compute metrics
+  output_metrics = {}
+  if not is_warmup:
+    # No need to calculate metrics when executing warmup requests
+    benchmark_duration = time.perf_counter() - benchmark_start_time
+    metrics = calculate_metrics(
+        input_requests=input_requests,
+        outputs=outputs,
+        dur_s=benchmark_duration,
+        tokenizer=tokenizer,
+    )
+    print(f"Successful requests: {metrics.completed}")
+    print(f"Benchmark duration: {benchmark_duration:2f} s")
+    print(f"Total input tokens: {metrics.total_input}")
+    print(f"Total generated tokens: {metrics.total_output}")
+    print(f"Request throughput: {metrics.request_throughput:.2f} requests/s")
+    print(f"Input token throughput: {metrics.input_throughput:.2f} tokens/s")
+    print(f"Output token throughput: {metrics.output_throughput:.2f} tokens/s")
 
-  metrics = calculate_metrics(
-      input_requests=input_requests,
-      outputs=outputs,
-      dur_s=benchmark_duration,
-      tokenizer=tokenizer,
-  )
+    print(f"{metrics.ttft.distribution_summary_str()}")
+    print(f"{metrics.ttst.distribution_summary_str()}")
+    print(f"{metrics.tpot.distribution_summary_str()}")
 
-  print(f"Successful requests: {metrics.completed}")
-  print(f"Benchmark duration: {benchmark_duration:2f} s")
-  print(f"Total input tokens: {metrics.total_input}")
-  print(f"Total generated tokens: {metrics.total_output}")
-  print(f"Request throughput: {metrics.request_throughput:.2f} requests/s")
-  print(f"Input token throughput: {metrics.input_throughput:.2f} tokens/s")
-  print(f"Output token throughput: {metrics.output_throughput:.2f} tokens/s")
-  print(f"Mean TTFT: {metrics.mean_ttft_ms:.2f} ms")
-  print(f"Median TTFT: {metrics.median_ttft_ms:.2f} ms")
-  print(f"P99 TTFT: {metrics.p99_ttft_ms:.2f} ms")
-  print(f"Mean TPOT: {metrics.mean_tpot_ms:.2f} ms")
-  print(f"Median TPOT: {metrics.median_tpot_ms:.2f} ms")
-  print(f"P99 TPOT: {metrics.p99_tpot_ms:.2f} ms")
+    # Calculate one rate for each 10 sec window. Adjusts the window size if
+    # needed to use csv output below for plotting the rate over time.
+    window_size_sec = 10
+    print(
+        f"----- Request complete rate time series "
+        f"(window_size = {window_size_sec} sec) -----"
+    )
+    print(f"{req_complete_cnt.rate_over_window_to_csv(window_size_sec)}")
+    print(
+        f"----- Output token rate time series "
+        f"(window_size = {window_size_sec} sec) -----"
+    )
+    print(f"{out_token_cnt.rate_over_window_to_csv(window_size_sec)}")
 
-  result = {
-      "duration": benchmark_duration,
-      "completed": metrics.completed,
-      "total_input_tokens": metrics.total_input,
-      "total_output_tokens": metrics.total_output,
-      "request_throughput": metrics.request_throughput,
-      "input_throughput": metrics.input_throughput,
-      "output_throughput": metrics.output_throughput,
-      "mean_ttft_ms": metrics.mean_ttft_ms,
-      "median_ttft_ms": metrics.median_ttft_ms,
-      "p99_ttft_ms": metrics.p99_ttft_ms,
-      "mean_tpot_ms": metrics.mean_tpot_ms,
-      "median_tpot_ms": metrics.median_tpot_ms,
-      "p99_tpot_ms": metrics.p99_tpot_ms,
-  }
-  return result, outputs
+    output_metrics = {
+        "duration": benchmark_duration,
+        "completed": metrics.completed,
+        "total_input_tokens": metrics.total_input,
+        "total_output_tokens": metrics.total_output,
+        "request_throughput": metrics.request_throughput,
+        "input_throughput": metrics.input_throughput,
+        "output_throughput": metrics.output_throughput,
+    }
+    output_metrics = {
+        **output_metrics,
+        **metrics.ttft.distribution_summary_dict(),
+        **metrics.ttst.distribution_summary_dict(),
+        **metrics.tpot.distribution_summary_dict(),
+    }
+  return output_metrics, outputs
 
 
 def mock_requests(total_mock_requests: int):
@@ -687,8 +748,8 @@ def main(args: argparse.Namespace):
     warmup_requests = list(sample_warmup_requests(input_requests)) * 2
 
   if warmup_requests:
-    print(f"Starting {args.warmup_mode} warmup:")
-    benchmark_result, request_outputs = asyncio.run(
+    print(f"Warmup (mode: {args.warmup_mode}) is starting.")
+    _, _ = asyncio.run(
         benchmark(
             api_url=api_url,
             tokenizer=tokenizer,
@@ -697,9 +758,10 @@ def main(args: argparse.Namespace):
             disable_tqdm=args.disable_tqdm,
             prefill_quota=prefill_quota,
             active_req_quota=active_req_quota,
+            is_warmup=True,
         )
     )
-    print(f"{args.warmup_mode} warmup completed.")
+    print(f"Warmup (mode: {args.warmup_mode}) has completed.")
 
   # TODO: Replace this with warmup complete signal once supported.
   # Wait for server completely warmup before running the benchmark.
@@ -770,7 +832,6 @@ def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-
   parser = argparse.ArgumentParser(
       description="Benchmark the online serving throughput."
   )

--- a/benchmarks/metrics.py
+++ b/benchmarks/metrics.py
@@ -1,0 +1,244 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metrics util classes for collecting and managing metrics."""
+
+import datetime
+
+import numpy as np
+from typing import Tuple, List, Dict
+
+
+def _floor_datetime_to_sec(timestamp: datetime.datetime) -> datetime.datetime:
+  """ "Floor the timestamp to the nearest most recent second"""
+  return timestamp.replace(microsecond=0)
+
+
+def _now_floored_to_second() -> datetime.datetime:
+  """Return the current timestamp floored to the nearest most recent second a"""
+  now = datetime.datetime.now()
+  return _floor_datetime_to_sec(now)
+
+
+class EventMetric:
+  """An event metric  for distribution stats reporting. Not thread-safe."""
+
+  def __init__(self, name: str, description: str, unit: str = ""):
+    self._name = name
+    self._description = description
+    self._unit = unit
+    self._data = []
+
+  def data(self) -> List[float]:
+    """Returns all stored data points.
+
+    Returns:
+      A list of data points in the order that was stored
+    """
+    return self._data
+
+  def record(self, value: float):
+    """Record a data point
+
+    Args:
+      value: The data point to be stored.
+    """
+    self._data.append(value)
+
+  def percentile(self, percentile: int) -> float:
+    """Computes and returns the specified percentile of the collected data.
+
+    Args:
+      percentile: The percentile to compute.
+
+    Returns:
+      The computed percentile.
+    """
+    if not 0 <= percentile <= 100:
+      raise ValueError(f"Percentile {percentile} is not in [0, 100]")
+    if not self._data:
+      raise ValueError(
+          f"No data points in metric {self._name} to compute percentile"
+      )
+    return np.percentile(self._data, percentile)
+
+  def mean(self) -> float:
+    """Calculates and returns the mean value of the collected data.
+
+    Returns:
+        The mean value of the collected data
+    """
+    if not self._data:
+      raise ValueError(f"No data points in metric {self._name} to compute mean")
+    return np.mean(self._data)
+
+  def distribution_summary_str(self) -> str:
+    """Generates a string representation of the distribution summary
+
+    Returns:
+        The string representation of the distribution summary including
+        mean, p50, p90 and p99.
+    """
+    s = ""
+    s += f"Mean {self._name}: {self.mean():.2f} {self._unit}\n"
+    s += f"Median {self._name}: {self.percentile(50):.2f} {self._unit}\n"
+    s += f"P99 {self._name}: {self.percentile(99):.2f} {self._unit}"
+    return s
+
+  def distribution_summary_dict(self) -> dict[str, float]:
+    """Generates a dictionary representation of the distribution summary
+
+    Returns:
+      A dictionary containing of the distribution summary including mean,
+      p50, p90 and p99.
+    """
+    return {
+        f"mean_{self._name}_{self._unit}": self.mean(),
+        f"median_{self._name}_{self._unit}": self.percentile(50),
+        f"p99_{self._name}_{self._unit}": self.percentile(99),
+    }
+
+
+class CounterMetric:
+  """A count metric for computing rates over time. Not thread-safe."""
+
+  def __init__(self, name: str, description: str):
+    self._name = name
+    self._description = description
+    self._data: dict[datetime.datetime, int] = {}
+
+  def data(self) -> Dict[datetime.datetime, int]:
+    """Returns all stored data points.
+
+    Returns:
+      A dictionary of data points where the key is the timestamp and the value
+      is the aggregated counts within the second of the timestamp.
+    """
+    return self._data
+
+  def total_count(self) -> int:
+    """Returns aggregated counts
+
+    Returns:
+      The aggregated counts.
+    """
+    return sum(self._data.values())
+
+  def total_duration_sec(self) -> int:
+    """Returns the duration between the first and last count increment
+
+    Returns:
+        The duration (in seconds) between the first and last increment
+        (inclusive of both ends).
+    """
+    start_time = min(self._data.keys())
+    end_time = max(self._data.keys())
+    return int((end_time - start_time).total_seconds() + 1)
+
+  def increment(
+      self, count: int = 1, timestamp: datetime.datetime | None = None
+  ):
+    """Increment the counter by count
+
+    Args:
+        count: The amount to increment
+        timestamp: The timestamp for the increment. Default to now if none is
+          provided.
+    """
+    if timestamp is None:
+      cur_time = _now_floored_to_second()
+    else:
+      cur_time = _floor_datetime_to_sec(timestamp)
+    # Add timestamp with default value 0 if doesn't exist
+    cur_count = self._data.setdefault(cur_time, 0)
+    self._data[cur_time] = cur_count + count
+    return
+
+  def rate(self) -> float:
+    """Calculates the rate of change between the first and last increments.
+
+    Returns:
+      The rate of change between the first and last increments.
+    """
+    if len(self._data.keys()) < 2:
+      raise ValueError(
+          "At least 2 data points are required to compute the rate"
+      )
+    start_time = min(self._data.keys())
+    end_time = max(self._data.keys())
+    delta_time_sec = (end_time - start_time).total_seconds()
+    sorted_counts = [count for timestamp, count in sorted(self._data.items())]
+    delta_count = sum(sorted_counts[1:])
+    return delta_count / delta_time_sec
+
+  def rate_over_window(
+      self, window_size_sec: int
+  ) -> List[Tuple[datetime.datetime, float]]:
+    """Calculate the rates over time."
+
+    Args:
+      window_size_sec: The size of the window in seconds for computing each
+        individual rate
+
+    Returns:
+      A list of rates over time, where each element represents the rate of
+      change for the specified window size.
+    """
+    if len(self._data.keys()) < 2:
+      raise ValueError(
+          f"At least 2 different timestamp values are required to calculate "
+          f"the rate, but have only {len(self._data.keys())}"
+      )
+    rates: List[Tuple[datetime.datetime, float]] = []
+    sorted_data = sorted(self._data.items())
+
+    start_time, _ = sorted_data[0]
+    end_time, _ = sorted_data[-1]
+    cur_start_time = start_time
+    cur_end_time = cur_start_time + datetime.timedelta(seconds=window_size_sec)
+    cur_total_count = 0
+    for data_point in sorted_data:
+      timestamp, count = data_point
+      if timestamp >= cur_end_time:
+        while timestamp >= cur_end_time:
+          rates.append((cur_start_time, cur_total_count / window_size_sec))
+          cur_start_time = cur_end_time
+          cur_end_time = cur_start_time + datetime.timedelta(
+              seconds=window_size_sec
+          )
+          cur_total_count = 0
+      cur_total_count += count
+    if cur_start_time <= end_time:
+      delta_time_sec = (end_time - cur_start_time).total_seconds() + 1
+      rates.append((cur_start_time, cur_total_count / delta_time_sec))
+    return rates
+
+  def rate_over_window_to_csv(self, window_size_sec: int) -> str:
+    """Compute and return the rates over time and return them in csv string
+
+    Args:
+      window_size_sec: The size of the window in seconds for computing each
+        individual rate
+
+    Returns:
+      A CSV string representation of the rates over time, with two rows:
+      the first row contains timestamps, and the second row contains rate
+      values.
+    """
+    rates = self.rate_over_window(window_size_sec)
+    # Generate CSV string with two rows
+    timestamps = "TimeStamp," + ",".join([str(e[0]) for e in rates])
+    values = "Value," + ",".join([f"{e[1]:.2f}" for e in rates])
+    csv_output = timestamps + "\n" + values
+    return csv_output

--- a/benchmarks/tests/test_metrics.py
+++ b/benchmarks/tests/test_metrics.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for metrics."""
+
+import unittest
+
+import benchmarks.metrics as metrics
+import datetime
+import re
+
+
+class TestEventMetric(unittest.TestCase):
+  """ "Tests for event metric (i.e. distribution)."""
+
+  def setUp(self):
+    self._metric = metrics.EventMetric(
+        "requestLatency", "Latency of requests", "ms"
+    )
+
+  def test_record_adds_a_data_event(self):
+    m = self._metric
+    m.record(1.0)
+    data_points = m.data()
+    self.assertEqual(1, len(data_points))
+    self.assertEqual(1.0, data_points[0])
+
+  def test_percentile_returns_correct_percentile(self):
+    m = self._metric
+    n = 11
+    for i in range(0, n):
+      m.record(i)
+    self.assertEqual(m.percentile(50), 5)
+    self.assertEqual(m.percentile(90), 9)
+    self.assertEqual(m.percentile(100), 10)
+
+  def test_mean_returns_correct_mean_value(self):
+    m = self._metric
+    n = 3
+    for i in range(0, n):
+      m.record(i)
+    self.assertEqual(sum(range(0, n)) / n, m.mean())
+
+  def test_distribution_summary_str_returns_expected_str(self):
+    m = self._metric
+    n = 100
+    for i in range(0, n):
+      m.record(i)
+    summary = m.distribution_summary_str()
+    self.assertTrue(re.search(r"Mean requestLatency", summary))
+    self.assertTrue(re.search(r"Median requestLatency", summary))
+    self.assertTrue(re.search(r"P99 requestLatency", summary))
+
+  def test_distribution_summary_dict_returns_expected_dict(self):
+    m = self._metric
+    n = 100
+    for i in range(0, n):
+      m.record(i)
+    summary = m.distribution_summary_dict()
+    self.assertIn("mean_requestLatency_ms", summary)
+    self.assertIn("median_requestLatency_ms", summary)
+    self.assertIn("p99_requestLatency_ms", summary)
+
+
+class TestCounterMetric(unittest.TestCase):
+  """Tests for counter metric (i.e. monotonically increasing counter)."""
+
+  def setUp(self):
+    self._counter = metrics.CounterMetric(
+        "RequestCompleteCount", "Number of completed requests"
+    )
+
+  def test_increment_increases_total_count(self):
+    m = self._counter
+    old_total_cnt = m.total_count()
+    m.increment()
+    new_total_cnt = m.total_count()
+    self.assertEqual(1, new_total_cnt - old_total_cnt)
+
+  def test_increment_within_same_second_update_counts_for_the_second(self):
+    """Test to ensure one entry used to cumulate counts within a second"""
+    m = self._counter
+    timestamp = datetime.datetime.strptime(
+        "2025-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"
+    )
+    m.increment(1, timestamp)
+    m.increment(2, timestamp)
+    data = m.data()
+    self.assertEqual(1, len(data.keys()))
+    self.assertEqual(3, data[timestamp])
+
+  def test_increment_at_different_seconds_creates_separate_entries(self):
+    """Test to ensure separate entries used for different seconds"""
+    m = self._counter
+    timestamp_first = datetime.datetime.strptime(
+        "2025-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"
+    )
+    m.increment(1, timestamp_first)
+    timestamp_second = datetime.datetime.strptime(
+        "2025-01-01 00:00:01", "%Y-%m-%d %H:%M:%S"
+    )
+    m.increment(2, timestamp_second)
+    data = m.data()
+    self.assertEqual(2, len(data.keys()))
+    self.assertEqual(1, data[timestamp_first])
+    self.assertEqual(2, data[timestamp_second])
+
+  def test_rate_returns_expected(self):
+    m = self._counter
+    n = 10
+    start_time = datetime.datetime.strptime(
+        "2025-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"
+    )
+    delta_time_sec = 1
+    for i in range(0, n):
+      m.increment(
+          1, start_time + datetime.timedelta(seconds=delta_time_sec * i)
+      )
+    # n counts across n seconds, thus rate = 1
+    self.assertEqual(1, m.rate())
+
+  def test_rate_over_window_returns_expected(self):
+    m = self._counter
+    n = 10
+    start_time = datetime.datetime.strptime(
+        "2025-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"
+    )
+    delta_time_sec = 1
+    for i in range(0, n):
+      m.increment(
+          1, start_time + datetime.timedelta(seconds=delta_time_sec * i)
+      )
+
+    rates_with_timestamp = m.rate_over_window(window_size_sec=5)
+
+    rates = [rate for timestamp, rate in rates_with_timestamp]
+    # 10 seconds with 1 count in each second. One rate per window_size_sec=5 sec
+    # so rate = 1 for [0, 5) and rate = 1 [5, 10)
+    self.assertEqual([1, 1], rates)
+
+  def test_rate_over_window_to_csv_returns_correct(self):
+    m = self._counter
+    n = 10
+    start_time = datetime.datetime.strptime(
+        "2025-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"
+    )
+    delta_time_sec = 1
+    for i in range(0, n):
+      m.increment(
+          1, start_time + datetime.timedelta(seconds=delta_time_sec * i)
+      )
+
+    csv_output = m.rate_over_window_to_csv(window_size_sec=5)
+
+    rows = csv_output.split("\n")
+    self.assertEqual(2, len(rows))
+    expected_timestamps = "TimeStamp,2025-01-01 00:00:00,2025-01-01 00:00:05"
+    got_timestamps = rows[0]
+    self.assertEqual(expected_timestamps, got_timestamps)
+    expected_values = "Value,1.00,1.00"
+    got_values = rows[1]
+    self.assertEqual(expected_values, got_values)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/jetstream/tests/core/test_orchestrator.py
+++ b/jetstream/tests/core/test_orchestrator.py
@@ -14,7 +14,7 @@
 
 """Integration test of the orchestrator.
 
-This test tests the multi-htreaded orchestrator, where a prefill request is
+This test tests the multithreaded orchestrator, where a prefill request is
 popped onto a prefill queue, prefilled, sent to a generation queue and run for
 a number of decoding steps.
 


### PR DESCRIPTION
Major changes
* TTST tracked and reported in benchmarking output
* request complete rate and output token throughput rate over time calculated and reported in csv string format for graph plotting

Minor changes
* typo fix in comment
* type annotation added in a few places
* python style fix to comply with Google style
* docstring added for a couple of method/function
* misc code cleanup

Reasons:
* TTST: Useful to track the response latency including kv cache transfer latency.
* Time series: Useful to plot a graph showing different stages of benchmarking (e.g. low output token throughput while generate batch still gets filled up, and high output token throughput when the generate batch is full)

Sample view of additional output in benchmarking result: ...
TTST mean: 572.02 ms
TTST p50: 578.94 ms
TTST p90: 731.77 ms
TTST p99: 814.23 ms
...
---- Request complete rate (window_size: 10sec) ---- TimeStamp,2025-01-06 07:32:52,2025-01-06 07:33:02,2025-01-06 07:33:12,2025-01-06 07:33:22,2025-01-06 07:33:32,2025-01-06 07:33:42,2025-01-06 07:33:52,2025-01-06 07:34:02,2025-01-06 07:34:12,2025-01-06 07:34:22,2025-01-06 07:34:32,2025-01-06 07:34:42,2025-01-06 07:34:52,2025-01-06 07:35:02,2025-01-06 07:35:12,2025-01-06 07:35:22,2025-01-06 07:35:32,2025-01-06 07:35:42,2025-01-06 07:35:52,2025-01-06 07:36:02,2025-01-06 07:36:12,2025-01-06 07:36:22,2025-01-06 07:36:32,2025-01-06 07:36:42,2025-01-06 07:36:52,2025-01-06 07:37:02,2025-01-06 07:37:12 Value,0.80,5.50,7.10,10.10,9.70,7.60,10.70,8.90,10.00,9.80,9.70,10.50,10.60,8.80,9.00,6.50,8.80,10.30,8.80,10.40,9.40,8.30,4.80,1.70,0.60,0.30,0.50 ---- Output token rate (window_size=10sec) ----
TimeStamp,2025-01-06 07:32:50,2025-01-06 07:33:00,2025-01-06 07:33:10,2025-01-06 07:33:20,2025-01-06 07:33:30,2025-01-06 07:33:40,2025-01-06 07:33:50,2025-01-06 07:34:00,2025-01-06 07:34:10,2025-01-06 07:34:20,2025-01-06 07:34:30,2025-01-06 07:34:40,2025-01-06 07:34:50,2025-01-06 07:35:00,2025-01-06 07:35:10,2025-01-06 07:35:20,2025-01-06 07:35:30,2025-01-06 07:35:40,2025-01-06 07:35:50,2025-01-06 07:36:00,2025-01-06 07:36:10,2025-01-06 07:36:20,2025-01-06 07:36:30,2025-01-06 07:36:40,2025-01-06 07:36:50,2025-01-06 07:37:00,2025-01-06 07:37:10 Value,567.40,1817.80,2371.00,2703.40,2644.80,2780.00,2784.50,2824.70,2849.60,2981.90,3001.00,2878.70,2657.10,2446.80,2468.40,2534.20,2646.00,2628.70,2696.20,2739.40,2827.50,2170.00,952.40,372.90,156.10,74.70,26.00 ...