### PR TITLE
Allow openorca customfile

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -245,12 +245,16 @@ def load_sharegpt_dataset(
   return dataset
 
 
-def load_openorca_dataset_pkl():
+def load_openorca_dataset_pkl(
+    dataset_path: str,
+) -> list[tuple[Any, Any]]:
+  if not dataset_path:
+    dataset_path = "open_orca_gpt4_tokenized_llama.calibration_1000.pkl"
   # read pickle file
   samples = pandas.read_pickle(
       os.path.join(
           os.path.dirname(os.path.relpath(__file__)),
-          "open_orca_gpt4_tokenized_llama.calibration_1000.pkl",
+          dataset_path,
       )
   )
 
@@ -663,7 +667,7 @@ def main(args: argparse.Namespace):
   else:
     dataset = []
     if args.dataset == "openorca":
-      dataset = load_openorca_dataset_pkl()
+      dataset = load_openorca_dataset_pkl(args.dataset_path)
     elif args.dataset == "sharegpt":
       dataset = load_sharegpt_dataset(
           args.dataset_path,


### PR DESCRIPTION
This will allow testing using mlperf datasets in addition to the hardcoded file available in JetStream repo