### PR TITLE
Do not set logging level to emit all logs

### DIFF
--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -99,10 +99,7 @@ from jetstream.core.metrics.prometheus import JetstreamMetricsCollector
 import numpy as np
 
 root = logging.getLogger()
-root.setLevel(logging.WARNING)
-
 handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.WARNING)
 formatter = logging.Formatter(
     "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )


### PR DESCRIPTION
Set logger to emit all logs. Previously was set to `INFO` logs only then `WARNING` logs only. Not setting the logger will emit all logs.  This reenables viewing the `INFO` logs in JetStream server logs.

Validated logic in maxengine-server to emit `INFO` logs- 

```
2025-01-10 02:20:18,057 - root - INFO - Detokenizing generate step 209 took 22.56ms
INFO:root:Detokenizing generate step 210 took 22.98ms
{"message": "Detokenizing generate step 210 took 22.98ms","severity": "INFO", "logging.googleapis.com/labels": {"python_logger": "root"}, "logging.googleapis.com/trace": "", "logging.googleapis.com/spanId": "", "logging.googleapis.com/trace_sampled": false, "logging.googleapis.com/sourceLocation": {"line": 897, "file": "/usr/local/lib/python3.10/dist-packages/jetstream/core/orchestrator.py", "function": "_detokenize_thread"}, "httpRequest": {} }
2025-01-10 02:20:18,080 - root - INFO - Detokenizing generate step 210 took 22.98ms
```