### PR TITLE
[Minor Bug] Fix a bug in the number of detokenize thread (found by fhzhang)

### DIFF
--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -404,7 +404,7 @@ class Driver:
             ),
             name=f"prefill_detokenize-{idx}",
         )
-        for idx in range(len(self._generate_engines))
+        for idx in range(len(self._prefill_engines))
     ]
     self.generate_detokenize_threads = [
         JetThread(


### PR DESCRIPTION
Issue:
self.prefill_detokenize_threads should have the same # of threads as # of prefill engines. 
While existing code creates num-of-generate-engines detokenize threads