### PR TITLE
Fix mutable default is not allowed error

### DIFF
--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -156,7 +156,9 @@ class ActiveRequest:
   generate_timestep_added: Optional[int] = None
   is_client_side_tokenization: Optional[bool] = False
   ################## Information relevant for metrics ###################
-  metadata: ActiveRequestMetadata = ActiveRequestMetadata()
+  metadata: ActiveRequestMetadata = dataclasses.field(
+      default_factory=ActiveRequestMetadata
+  )
 
   def enqueue_samples(self, generated_samples: list[ReturnSample]):
     """Adds the generated sample(s) to return channel for current step.


### PR DESCRIPTION
py3.11 enforce the behavior that mutable default is not allowed in dataclass.