### PR TITLE
[Minor Bug] Fix a bug in the blocking algorithm of the generate thread.

### DIFF
--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -710,7 +710,8 @@ class Driver:
           # For interleaved mode, we also blocks when prefill backlog
           # is not empty or there are transfer work to do.
           block |= not self._prefill_backlog.empty()
-          block |= not self._transfer_backlogs[idx].empty()
+          for transfer_backlog in self._transfer_backlogs:
+            block |= not transfer_backlog.empty()
         try:
           new_request = my_generate_backlog.get(block=block, timeout=1.0)
           if new_request is None:


### PR DESCRIPTION
`_transfer_backlogs` isn't 1:1 with `generate_threads` so we cannot use `generate_thread`'s index to access _transfer_backlogs. Instead, we should block when any `transfer_backlog` is non-empty.