### PR TITLE
Nit: Remove the Link Causing Copybara Leaker issue 

### DIFF
--- a/docs/observability-prometheus-metrics-in-jetstream-server.md
+++ b/docs/observability-prometheus-metrics-in-jetstream-server.md
@@ -80,6 +80,6 @@ echo '{
   }' | kubectl apply -f -
   ```
 
-The metrics can now be queried in the [Google Cloud Metrics Explorer](https://pantheon.corp.google.com/monitoring/metrics-explorer). When adding a metrics query with the `+Add Query` button the new metrics should be found under the `Prometheus Target > Jetstream` submenu.
+The metrics can now be queried in the Google Cloud Metrics Explorer. When adding a metrics query with the `+Add Query` button the new metrics should be found under the `Prometheus Target > Jetstream` submenu.
 
 Additional guides on the metrics explorer can be found [here](https://cloud.google.com/monitoring/charts/metrics-selector).


### PR DESCRIPTION
Error: Migration of origin revision '723590807' failed with error: Leakr log contained at least one ERROR or FATAL indicating go/leakr found disallowed strings in the export:
leakr: observability-prometheus-metrics-in-jetstream-server.md:83 [ERROR] "corp.google.com": "The metrics can now be queried in the [Google Cloud Metrics Explorer](https://pantheon.corp.google.com/monitoring/metric..

Remove the link so that copybara won't complain about it. 