### PR TITLE
[TestCleanup] Clean up test_server.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs/
 tmp/
 venv/
 .vscode/
+.idea/

--- a/benchmarks/mlperf/main.py
+++ b/benchmarks/mlperf/main.py
@@ -140,7 +140,7 @@ def get_args():
       type=str,
       default=_MLPERF_ID,
       help="When given overrides the default user.conf path",
- )
+  )
   args = parser.parse_args()
   return args
 


### PR DESCRIPTION
* Change from assert to self.assert
* Change unittest.IsolatedAsyncioTestCase to TestCase to run tests synchronously and sequentially to avoid following warning (which seems to be due to underlying grpc issue https://github.com/grpc/grpc/issues/25364)

```
BlockingIOError: [Errno 35] Resource temporarily unavailable
```