### PR TITLE
[test] Add a unit test for paged attention kernel

### DIFF
--- a/experimental/jax/inference/kernel/attention/tpu/paged_attention.py
+++ b/experimental/jax/inference/kernel/attention/tpu/paged_attention.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""PagedAttention TPU kernel for decode phase (ported from jax 0.4.33 for quick experiment)"""
+"""PagedAttention TPU kernel."""
 
 from collections.abc import Sequence
 import functools
@@ -645,8 +645,9 @@ def paged_attention(
           grid=grid,
           scratch_shapes=scratch_shapes,
       ),
-      # compiler_params=pltpu.TPUCompilerParams(
-      #     dimension_semantics=dimension_semantics),
+      compiler_params=pltpu.TPUCompilerParams(
+          dimension_semantics=dimension_semantics
+      ),
       out_shape=[
           jax.ShapeDtypeStruct(q.shape, q_dtype_for_kernel_launch),
           jax.ShapeDtypeStruct((*q.shape[:-1], 1), jnp.float32),

--- a/experimental/jax/inference/kernel/attention/tpu/paged_attention_test.py
+++ b/experimental/jax/inference/kernel/attention/tpu/paged_attention_test.py
@@ -1,0 +1,192 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax._src import test_util as jtu
+from jax.experimental.pallas.ops.tpu import paged_attention
+from jax.experimental.pallas.ops.tpu.paged_attention import quantization_utils
+import jax.numpy as jnp
+import numpy as np
+
+
+jax.config.parse_flags_with_absl()
+
+
+def _generate_qkv(
+    seq_lens,
+    page_size,
+    max_seq_len,
+    num_kv_heads,
+    num_heads,
+    head_dim,
+    prng_key,
+    dtype=jnp.float32,
+    are_kv_quantized=False,
+):
+  assert max_seq_len % page_size == 0
+  pages_per_sequence = max_seq_len // page_size
+  batch_size = len(seq_lens)
+  total_pages = batch_size * pages_per_sequence
+  k1, k2, k3, k4 = jax.random.split(prng_key, 4)
+  k_pages = jax.random.normal(
+      k1, (num_kv_heads, total_pages, page_size, head_dim), dtype=dtype
+  )
+  v_pages = jax.random.normal(
+      k2, (num_kv_heads, total_pages, page_size, head_dim), dtype=dtype
+  )
+
+  if are_kv_quantized:
+    k_pages = quantization_utils.quantize_to_int8(k_pages)
+    v_pages = quantization_utils.quantize_to_int8(v_pages)
+
+  page_indices = jnp.arange(batch_size * pages_per_sequence, dtype=jnp.int32)
+  page_indices = jax.random.permutation(k3, page_indices, independent=True)
+  page_indices = page_indices.reshape(batch_size, pages_per_sequence)
+  q = jax.random.normal(k4, (batch_size, num_heads, head_dim), dtype=dtype)
+  return q, k_pages, v_pages, page_indices
+
+
+def _reconstruct_kv(page_indices, pages):
+  if isinstance(pages, quantization_utils.QuantizedTensor):
+    pages = quantization_utils.unquantize_from_int8(pages, dtype=jnp.float32)
+
+  batch_size = page_indices.shape[0]
+  num_heads, _, _, head_dim = pages.shape
+
+  def per_sequence_page_gather(pages, page_indices):
+    return jnp.take(pages, page_indices, 1)
+
+  gathered = jax.vmap(per_sequence_page_gather, in_axes=(None, 0))(
+      pages, page_indices
+  )
+  return gathered.reshape(batch_size, num_heads, -1, head_dim)
+
+
+def _grouped_query_attention_reference(q, k, v, lengths, attn_logits_soft_cap):
+  batch_size, num_heads, head_dim = q.shape
+  _, num_kv_heads, max_seq_len, _ = k.shape
+  assert k.shape == v.shape
+  assert num_heads % num_kv_heads == 0
+  q = q.reshape(batch_size, num_kv_heads, num_heads // num_kv_heads, head_dim)
+
+  if isinstance(k, quantization_utils.QuantizedTensor):
+    k = quantization_utils.unquantize_from_int8(k, dtype=jnp.float32)
+  if isinstance(v, quantization_utils.QuantizedTensor):
+    v = quantization_utils.unquantize_from_int8(v, dtype=jnp.float32)
+
+  logits = jnp.einsum(
+      "bhgd,bhtd->bhgt", q.astype(jnp.float32), k.astype(jnp.float32)
+  )
+  if attn_logits_soft_cap is not None:
+    logits = jnp.tanh(logits / attn_logits_soft_cap) * attn_logits_soft_cap
+  mask = jnp.arange(max_seq_len)[None] < lengths[:, None]
+  mask_value = -0.7 * float(np.finfo(np.dtype("float32")).max)
+  logits = logits + jnp.where(mask, 0.0, mask_value)[:, None, None, :]
+  weights = jax.nn.softmax(logits, axis=-1)
+  o = jnp.einsum("bhgt,bhtd->bhgd", weights.astype(v.dtype), v)
+  return o.reshape(batch_size, num_heads, head_dim)
+
+
+def _megacore_enabled():
+  return jax.devices()[0].device_kind == "TPU v4" or jtu.is_device_tpu(
+      version=5, variant="p"
+  )
+
+
+@jtu.with_config(jax_numpy_dtype_promotion="standard")
+class PagedAttentionKernelTest(jtu.JaxTestCase):
+
+  @parameterized.product(
+      dtype=(jnp.float32, jnp.bfloat16),
+      page_size=(16, 32, 64),
+      num_kv_heads=(1, 8),
+      q_kv_head_ratio=(1, 4, 8),
+      head_dim=(128, 256),
+      megacore_mode=("batch", "kv_head", None),
+      attn_logits_soft_cap=(1.0, None),
+      are_kv_quantized=(
+          False,
+          True,
+      ),
+  )
+  def test_paged_attention(
+      self,
+      dtype,
+      page_size,
+      num_kv_heads,
+      q_kv_head_ratio,
+      head_dim,
+      megacore_mode,
+      attn_logits_soft_cap,
+      are_kv_quantized,
+  ):
+    if not jtu.is_device_tpu_at_least(4):
+      self.skipTest("Only supports TPU generation 4 or above")
+    if jtu.is_device_tpu(version=4) and are_kv_quantized:
+      # TPU v4 has only 16MiB of VMEM which is not sufficient to store both the
+      # weight and scale tensors for quantized tensors. When enabled on TPUv4,
+      # the tests sometimes failed with resource exhausted error.
+      self.skipTest("Quantization is not supported on TPU v4")
+    if jtu.is_device_tpu_at_least(6) and are_kv_quantized:
+      self.skipTest("Quantization is not supported on TPU v6")
+    if megacore_mode and not _megacore_enabled():
+      self.skipTest("Megacore is only available on TPU v4 or TPU v5p")
+    if num_kv_heads % 2 != 0 and megacore_mode == "kv_head":
+      self.skipTest("Skip kv_head megacore mode when num_kv_heads is odd")
+    max_kv_len = 2048
+    block_size = 512
+    seq_lens = np.asarray([0, 3, 256, 513, 1023, 2048])
+    q, k_pages, v_pages, page_indices = _generate_qkv(
+        seq_lens,
+        page_size,
+        max_kv_len,
+        num_kv_heads,
+        num_kv_heads * q_kv_head_ratio,
+        head_dim,
+        jax.random.key(0),
+        dtype,
+        are_kv_quantized=are_kv_quantized,
+    )
+    o = paged_attention.paged_attention(
+        q,
+        k_pages,
+        v_pages,
+        seq_lens,
+        page_indices,
+        pages_per_compute_block=block_size // page_size,
+        megacore_mode=megacore_mode,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+    )
+    k = _reconstruct_kv(page_indices, k_pages)
+    v = _reconstruct_kv(page_indices, v_pages)
+    o_ref = _grouped_query_attention_reference(
+        q, k, v, seq_lens, attn_logits_soft_cap
+    )
+
+    if q_kv_head_ratio > 1:
+      atol, rtol = 1e-2, 2e-2
+    else:
+      atol, rtol = 2e-1, 1e-1
+    np.testing.assert_allclose(
+        o[np.where(seq_lens > 0)].astype(jnp.float32),
+        o_ref[np.where(seq_lens > 0)].astype(jnp.float32),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/experimental/jax/inference/kernel/attention/tpu/quantization_utils.py
+++ b/experimental/jax/inference/kernel/attention/tpu/quantization_utils.py
@@ -17,8 +17,7 @@ import jax
 from jax import numpy as jnp
 
 P = jax.sharding.PartitionSpec
-MAX_INT8 = 127
-MIN_INT8 = -128
+MAX_INT8 = 127.5
 
 
 class QuantizedTensor(NamedTuple):
@@ -43,8 +42,7 @@ def to_int8(x: jnp.ndarray, h: jnp.ndarray) -> jnp.ndarray:
   Returns:
     Int8 array.
   """
-  x = x * h
-  return jnp.clip(jnp.round(x), MIN_INT8, MAX_INT8).astype(jnp.int8)
+  return jnp.int8(jnp.rint(x * (MAX_INT8 / h)))
 
 
 def from_int8(
@@ -60,11 +58,10 @@ def from_int8(
   Returns:
     Float array.
   """
-  x = x.astype(dtype=dtype) / h
-  return x.astype(dtype=dtype)
+  return x.astype(dtype) * h / MAX_INT8
 
 
-def get_quantization_scales(x: jnp.ndarray, axis=-1) -> jnp.ndarray:
+def get_quantization_scales(x: jnp.ndarray) -> jnp.ndarray:
   """Computes the quantization scales for a float array.
 
   These are the maximum values of the trailing dimension.
@@ -76,13 +73,11 @@ def get_quantization_scales(x: jnp.ndarray, axis=-1) -> jnp.ndarray:
     Array of the same shape as input but with the trailing dimension reduced to
     a size 1 absolute max value.
   """
-  scale_reciprocal = MAX_INT8 / jnp.max(jnp.abs(x), axis=axis, keepdims=True)
-  return scale_reciprocal.astype(jnp.float32)
+  return jnp.max(jnp.abs(x), axis=-1, keepdims=True)
 
 
 def quantize_to_int8(
     x: jnp.ndarray,
-    axis=-1,
 ) -> QuantizedTensor:
   """Quantizes a float array to an int8 QuantizedTensor.
 
@@ -92,7 +87,7 @@ def quantize_to_int8(
   Returns:
     Int8 QuantizedTensor.
   """
-  x_scales = get_quantization_scales(x, axis=axis)
+  x_scales = get_quantization_scales(x)
   return QuantizedTensor(weight=to_int8(x, x_scales), scales=x_scales)
 
 


### PR DESCRIPTION
- Updated kernel to the latest [jax experimental code](https://github.com/jax-ml/jax/blob/main/jax/experimental/pallas/ops/tpu/paged_attention/paged_attention_kernel.py)
- Copied the kernel test code from [jax test](https://github.com/jax-ml/jax/blob/main/tests/pallas/tpu_paged_attention_kernel_test.py)