### PR TITLE
[cleanup/fix] Make inference parameters explicit, etc.

### DIFF
--- a/experimental/jax/inference/entrypoint/mini_offline_benchmarking.py
+++ b/experimental/jax/inference/entrypoint/mini_offline_benchmarking.py
@@ -46,11 +46,15 @@ def _load_openorca_dataset(size: int, shuffle: bool) -> list[str]:
 
 
 def benchmark():
-  size = 10_000
+  size = 24_000
   dataset = _load_openorca_dataset(size=size, shuffle=True)
   assert len(dataset) == size
 
-  inference = offline_inference.OfflineInference()
+  inference = offline_inference.OfflineInference(
+      model_id="meta-llama/Llama-2-7b-chat-hf",
+      num_engines=1,
+      enable_multiprocessing=False,
+  )
 
   start_time = time.perf_counter()
   res_list: list[Response] = inference(dataset)

--- a/experimental/jax/inference/kernel/attention/tpu/chunked_prefill_attention.py
+++ b/experimental/jax/inference/kernel/attention/tpu/chunked_prefill_attention.py
@@ -201,6 +201,9 @@ def chunked_prefill_attention(
   """TPU chunked prefill attention."""
   chunk_size, num_attn_heads, head_dim = q.shape
   num_kv_heads, _, page_size, _ = k_pages.shape
+
+  assert num_attn_heads % num_kv_heads == 0
+  assert chunk_size % page_size == 0
   attn_group_size = num_attn_heads // num_kv_heads
   page_per_chunk = chunk_size // page_size
 

--- a/experimental/jax/inference/model/management/hf_llama_ckpt_conversion.py
+++ b/experimental/jax/inference/model/management/hf_llama_ckpt_conversion.py
@@ -18,7 +18,7 @@ limitations under the License.
 
 from jax import numpy as jnp
 from transformers import LlamaConfig
-from .util import convert_to_jax_array
+from .util import convert_to_jax_array_on_cpu
 
 
 def merge_gate_up_proj_weights(gate, up, num_devices):
@@ -43,18 +43,18 @@ def merge_gate_up_proj_weights(gate, up, num_devices):
 def convert_hf_llama(torch_weight_state, num_devices, config: LlamaConfig):
   jax_weight_state = {
       "embed_tokens": {
-          "weight": convert_to_jax_array(
+          "weight": convert_to_jax_array_on_cpu(
               torch_weight_state["model.embed_tokens.weight"]
           ),
       },
       "layers": {},
       "norm": {
-          "weight": convert_to_jax_array(
+          "weight": convert_to_jax_array_on_cpu(
               torch_weight_state["model.norm.weight"]
           ),
       },
       "lm_head": {
-          "weight": convert_to_jax_array(
+          "weight": convert_to_jax_array_on_cpu(
               torch_weight_state["lm_head.weight"].T
           ),
       },
@@ -64,10 +64,10 @@ def convert_hf_llama(torch_weight_state, num_devices, config: LlamaConfig):
   del torch_weight_state["lm_head.weight"]
   for i in range(config.num_hidden_layers):
     gate_up_proj_weight = merge_gate_up_proj_weights(
-        gate=convert_to_jax_array(
+        gate=convert_to_jax_array_on_cpu(
             torch_weight_state[f"model.layers.{i}.mlp.gate_proj.weight"].T
         ),
-        up=convert_to_jax_array(
+        up=convert_to_jax_array_on_cpu(
             torch_weight_state[f"model.layers.{i}.mlp.up_proj.weight"].T
         ),
         num_devices=num_devices,
@@ -77,28 +77,28 @@ def convert_hf_llama(torch_weight_state, num_devices, config: LlamaConfig):
     jax_weight_state["layers"][i] = {
         "self_attn": {
             "q_proj": {
-                "weight": convert_to_jax_array(
+                "weight": convert_to_jax_array_on_cpu(
                     torch_weight_state[
                         f"model.layers.{i}.self_attn.q_proj.weight"
                     ].T
                 ),
             },
             "k_proj": {
-                "weight": convert_to_jax_array(
+                "weight": convert_to_jax_array_on_cpu(
                     torch_weight_state[
                         f"model.layers.{i}.self_attn.k_proj.weight"
                     ].T
                 ),
             },
             "v_proj": {
-                "weight": convert_to_jax_array(
+                "weight": convert_to_jax_array_on_cpu(
                     torch_weight_state[
                         f"model.layers.{i}.self_attn.v_proj.weight"
                     ].T
                 ),
             },
             "o_proj": {
-                "weight": convert_to_jax_array(
+                "weight": convert_to_jax_array_on_cpu(
                     torch_weight_state[
                         f"model.layers.{i}.self_attn.o_proj.weight"
                     ].T
@@ -110,7 +110,7 @@ def convert_hf_llama(torch_weight_state, num_devices, config: LlamaConfig):
                 "weight": gate_up_proj_weight,
             },
             "down_proj": {
-                "weight": convert_to_jax_array(
+                "weight": convert_to_jax_array_on_cpu(
                     torch_weight_state[
                         f"model.layers.{i}.mlp.down_proj.weight"
                     ].T
@@ -118,12 +118,12 @@ def convert_hf_llama(torch_weight_state, num_devices, config: LlamaConfig):
             },
         },
         "input_layernorm": {
-            "weight": convert_to_jax_array(
+            "weight": convert_to_jax_array_on_cpu(
                 torch_weight_state[f"model.layers.{i}.input_layernorm.weight"]
             ),
         },
         "post_attention_layernorm": {
-            "weight": convert_to_jax_array(
+            "weight": convert_to_jax_array_on_cpu(
                 torch_weight_state[
                     f"model.layers.{i}.post_attention_layernorm.weight"
                 ]

--- a/experimental/jax/inference/model/management/registry.py
+++ b/experimental/jax/inference/model/management/registry.py
@@ -21,7 +21,7 @@ from typing import Any
 from jax.sharding import Mesh
 from jax import numpy as jnp
 from transformers import (
-    logging as hf_logging,
+    logging,
     AutoModelForCausalLM,
     AutoTokenizer,
     AutoConfig,
@@ -29,153 +29,53 @@ from transformers import (
     PreTrainedTokenizer,
 )
 from inference import nn
-from inference.model.llama import LlamaForCausalLM
 from .hf_llama_ckpt_conversion import convert_hf_llama
 from .util import torch_jax_dtype_map
 
-hf_logging.set_verbosity_error()
+logging.set_verbosity_error()
 
-supported_model = [
+supported_models = (
     "meta-llama/Llama-2-7b-chat-hf",
     "meta-llama/Llama-2-7b-hf",
-    "maxtext/Llama2-7b",
-]
-
-maxtext_config_map = {
-    "maxtext/Llama2-7b": "meta-llama/Llama-2-7b-chat-hf",
-}
-
-hf_ckpt_conversion = {
-    "meta-llama/Llama-2-7b-chat-hf": convert_hf_llama,
-    "meta-llama/Llama-2-7b-hf": convert_hf_llama,
-}
-
-hf_model_class_map: dict[str, nn.CausalLM] = {
-    "meta-llama/Llama-2-7b-chat-hf": LlamaForCausalLM,
-    "meta-llama/Llama-2-7b-hf": LlamaForCausalLM,
-}
+)
 
 
 @enum.unique
 class ModelSource(enum.Enum):
   NATIVE = enum.auto()
   HUGGINGFACE = enum.auto()
-  MAXTEXT = enum.auto()
 
 
 class ModelRegistry:
 
-  def load_model_config(
-      self,
-      model_id: str,
-      source: ModelSource = ModelSource.HUGGINGFACE,
-  ) -> PretrainedConfig:
-    if model_id not in supported_model:
-      raise ValueError(f"{model_id} is not supported")
+  def load_tokenizer(self, model_id: str) -> PreTrainedTokenizer:
+    print("Loading tokenizer")
+    print("-" * 60)
+    return AutoTokenizer.from_pretrained(model_id)
 
-    if source == ModelSource.MAXTEXT:
-      model_id = maxtext_config_map[model_id]
-
-    config = AutoConfig.from_pretrained(model_id)
-    return config
-
-  def load_tokenizer(
-      self,
-      model_id: str,
-      source: ModelSource = ModelSource.HUGGINGFACE,
-      path: str | None = None,
-  ) -> PreTrainedTokenizer:
-    if model_id not in supported_model:
-      raise ValueError(f"{model_id} is not supported")
-
-    if path:
-      raise ValueError(
-          f"Load tokenizer from given path {path} is not supported"
-      )
-
-    if source == ModelSource.MAXTEXT:
-      model_id = maxtext_config_map[model_id]
-
-    tokenizer = AutoTokenizer.from_pretrained(model_id)
-    return tokenizer
-
-  def model_cls(self, model_id: str):
-    model_cls = hf_model_class_map[model_id]
-    return model_cls
-
-  def load_model(
-      self,
-      mesh: Mesh,
-      model_id: str,
-      model_config: PretrainedConfig | None = None,
-      path: str | None = None,
-      source: ModelSource = ModelSource.HUGGINGFACE,
-      dtype: jnp.dtype = jnp.bfloat16,
-  ) -> tuple[nn.Module, dict]:
-    if model_config:
-      config = model_config
-    else:
-      config = self.load_model_config(model_id)
-
-    weights_on_host = self.load_weights_to_host(
-        model_id,
-        mesh.devices.size,
-        path,
-        source,
-        dtype,
-        config,
-    )
-    print("loaded to host")
-    if model not in hf_model_class_map:
-      raise ValueError(f"cannot find class for model {model}")
-    model_cls = hf_model_class_map[model]
-    model: nn.Module = model_cls(config, mesh)
-    print("loading to device")
-    weight_dict = model.load_weights_dict(weights_on_host)
-    print("loaded to device")
-    return model, weight_dict
+  def load_model_config(self, model_id: str) -> PretrainedConfig:
+    print("Loading model config")
+    print("-" * 60)
+    return AutoConfig.from_pretrained(model_id)
 
   def load_weights_to_host(
       self,
       model_id: str,
       num_devices: int,
-      model_config: PretrainedConfig | None = None,
-      path: str | None = None,
-      source: ModelSource = ModelSource.HUGGINGFACE,
-      dtype: jnp.dtype = jnp.bfloat16,
+      model_config: PretrainedConfig,
+      dtype: jnp.dtype,
   ) -> Any:
     """Load the ckpt to the host DRAM."""
+    assert model_id in supported_models, f"{model_id} is not supported"
+    print("Loading model weights to host")
+    print("-" * 60)
+    hg_model = AutoModelForCausalLM.from_pretrained(
+        model_id,
+        torch_dtype=torch_jax_dtype_map[dtype],
+        config=model_config,
+    )
+    state_dict = hg_model.state_dict()
+    del hg_model
 
-    if model_id not in supported_model:
-      raise ValueError(f"{model_id} is not supported")
-    if dtype not in torch_jax_dtype_map:
-      raise ValueError(f"Unknown jax dtype for weight to load {dtype}")
-
-    if source == ModelSource.HUGGINGFACE:
-      if model_id not in hf_ckpt_conversion:
-        raise ValueError(
-            f"No weight conversion function for HF model {model_id}"
-        )
-
-      if model_config:
-        config = model_config
-      else:
-        config = AutoConfig.from_pretrained(model_id)
-
-      if not path:
-        hg_model = AutoModelForCausalLM.from_pretrained(
-            model_id,
-            torch_dtype=torch_jax_dtype_map[dtype],
-            config=config,
-        )
-        ckpt_conversion_func = hf_ckpt_conversion[model_id]
-        state_dict = hg_model.state_dict()
-        del hg_model
-        weights = ckpt_conversion_func(state_dict, num_devices, config)
-        return weights
-      else:
-        raise NotImplemented(
-            "Loading from path for HF model is not supported yet"
-        )
-
-    raise NotImplemented(f"Loading from {source} is not supported yet")
+    weights = convert_hf_llama(state_dict, num_devices, model_config)
+    return weights

--- a/experimental/jax/inference/model/management/util.py
+++ b/experimental/jax/inference/model/management/util.py
@@ -27,8 +27,9 @@ torch_jax_dtype_map = {
 }
 
 
-def convert_to_jax_array(x: torch.Tensor):
+def convert_to_jax_array_on_cpu(x: torch.Tensor):
+  device = jax.devices("cpu")[0]
   return jax.device_put(
       jnp.asarray(x.float().numpy(), dtype=torch_jax_dtype_map[x.dtype]),
-      device=jax.devices("cpu")[0],
+      device=device,
   )

--- a/experimental/jax/inference/nn/module.py
+++ b/experimental/jax/inference/nn/module.py
@@ -52,6 +52,7 @@ class Module:
     return None
 
   def init_weights(self):
+    print("Initializing random model weights to devices ...")
     res = {}
     rng = jax.random.key(0)
     for k, param in self._parameters.items():
@@ -64,6 +65,7 @@ class Module:
     return res
 
   def load_weights_dict(self, weights_dict):
+    print("Loading model weights to devices: " + str(len(weights_dict)))
     res = {}
     for k, v in weights_dict.items():
       attr = getattr(self, k)

--- a/experimental/jax/inference/parallel/config.py
+++ b/experimental/jax/inference/parallel/config.py
@@ -114,7 +114,7 @@ class LinearParallelConfig:
 @dataclasses.dataclass
 class RMSNormParallelConfig:
   mesh: jax.sharding.Mesh
-  activation_shared: bool = False
+  activation_sharded: bool = False
 
 
 @enum.unique

--- a/experimental/jax/inference/parallel/mesh.py
+++ b/experimental/jax/inference/parallel/mesh.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 """mesh module"""
 
+import math
 from collections.abc import Iterable
 from typing import Sequence
 import jax
@@ -29,7 +30,7 @@ from inference.parallel.device import platform
 
 def create_device_mesh(
     devices: Sequence[Device],
-    shape: int | Sequence[int],
+    shape: tuple[int],
 ) -> Mesh:
   """Create a powerful mesh given the devices and shape.
 
@@ -39,38 +40,31 @@ def create_device_mesh(
   will affect the performance. (it depends on the collective algorithm
   implementation.)
   """
-  if len(devices) == 0:
-    raise ValueError("no devices is provided for mesh creation")
-
+  assert devices, "no devices is provided for mesh creation"
+  assert len(devices) == math.prod(shape)
   axis_names = (
       ParallelAxis.X.name,
       ParallelAxis.Y.name,
   )
+  assert len(shape) == len(axis_names)
 
-  if not isinstance(shape, Sequence):
-    shape = (shape,)
-
-  shape = tuple(list(shape) + [1 for _ in range(len(axis_names) - len(shape))])
-
-  if len(shape) != len(axis_names):
-    raise ValueError(
-        f"The number of mesh dimensions {len(shape)}"
-        + "doesn't match with number of axis_names {axis_names}"
-    )
-  if platform == "gpu" or platform == "cpu":
+  p = platform()
+  if p == "gpu" or p == "cpu":
     devices = jax_mesh_utils.create_device_mesh(
         mesh_shape=shape,
         devices=devices,
         allow_split_physical_axes=True,
     )
     return Mesh(devices=devices, axis_names=axis_names)
-
-  # TODO: Figure out a general method.
-  # Current mesh builder is very limited.
-  # only support (2,x) underlying topology shape to .
-  # form a 1D ring for the devices.
-  devices = devices[::2] + devices[1::2][::-1]
-  return Mesh(devices=np.reshape(devices, shape), axis_names=axis_names)
+  else:
+    assert p == "tpu"
+    # TODO: Figure out a general method.
+    # Current mesh builder is very limited.
+    # only support (2,x) underlying topology shape to .
+    # form a 1D ring for the devices.
+    devices = devices[::2] + devices[1::2][::-1]
+    devices = np.reshape(devices, shape)
+    return Mesh(devices=devices, axis_names=axis_names)
 
 
 def get_num_partitions(axis_names):

--- a/experimental/jax/inference/runtime/batch_scheduler.py
+++ b/experimental/jax/inference/runtime/batch_scheduler.py
@@ -56,14 +56,14 @@ class BatchScheduler:
   def __init__(
       self,
       kv_cache_manager: KVCacheManager,
-      max_num_seqs: int,
+      batch_size: int,
       max_seq_len: int,
       schedule_policy: SchedulePolicy = SchedulePolicy.OFFLINE,
   ):
     self.prefill_queue: queue.Queue[PrefillRequest] = queue.Queue()
     self.generate_queue: queue.Queue[GenerateRequest] = queue.Queue()
     self.kv_manager = kv_cache_manager
-    self.max_num_seqs = max_num_seqs
+    self.batch_size = batch_size
     self.max_seq_len = max_seq_len
     self.schedule_policy = schedule_policy
 
@@ -133,7 +133,7 @@ class BatchScheduler:
           or (
               len(generate_state.active_slot_req_map)
               + self.generate_queue.qsize()
-              > 0.95 * self.max_num_seqs
+              > 0.95 * self.batch_size
           )
       ):
         # Add new generate request to the slots.
@@ -158,7 +158,7 @@ class BatchScheduler:
             and len(alloced_pages) == 0
         ):
           raise NotImplementedError(
-              "Eviction isn't supported yet, please set a lower value for max_num_seqs"
+              "Eviction isn't supported yet, please set a lower value for batch_size"
           )
 
         page_to_use = 0

--- a/experimental/jax/inference/runtime/request_type.py
+++ b/experimental/jax/inference/runtime/request_type.py
@@ -86,9 +86,9 @@ class GenerateRequest:
 class GenerateState:
   """generate phase state"""
 
-  token_ids: jax.Array  # num_max_seq
-  positions: jax.Array  # num_max_seq
-  page_table: jax.Array  # num_max_seq, num_pages_per_seq
+  token_ids: jax.Array  # batch_size
+  positions: jax.Array  # batch_size
+  page_table: jax.Array  # batch_size, num_pages_per_seq
   available_slots: queue.SimpleQueue
   active_slot_req_map: dict[int, GenerateRequest]
   map_mutex: threading.Lock = threading.Lock()

--- a/experimental/jax/tests/nn/test_norm.py
+++ b/experimental/jax/tests/nn/test_norm.py
@@ -45,7 +45,7 @@ class NormTest(absltest.TestCase):
         eps=eps,
         parallel_config=parallel.RMSNormParallelConfig(
             mesh=mesh,
-            activation_shared=False,
+            activation_sharded=False,
         ),
     )
     distributed_rmsnorm_layer = nn.RMSNorm(
@@ -53,7 +53,7 @@ class NormTest(absltest.TestCase):
         eps=eps,
         parallel_config=parallel.RMSNormParallelConfig(
             mesh=mesh,
-            activation_shared=True,
+            activation_sharded=True,
         ),
     )
 


### PR DESCRIPTION
- Rename max_num_seq to batch_size
- Fix a process runner typo
- ......

```
$ python experimental/jax/inference/entrypoint/mini_offline_benchmarking.py

Offline inference begins: 2025-02-19 18:51:29.910043 ...
Offline inference ends: 2025-02-19 19:15:14.701318
Benchmarking result:
  Total requests: 24000
  Total input tokens: 5311141
  Total output tokens: 7030596
  Input token thruput:  3727.18 tokens/sec
  Output token thruput:  4933.84 tokens/sec
```