### PR TITLE
Fix the output length issue of Math 500 dataset.

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -437,6 +437,9 @@ def filter_dataset(
     if prompt_len > 1024 or prompt_len + output_len > 2048:
       # Prune too long sequences.
       continue
+    # TODO: should pass in the actual solution length instead of hardcode.
+    if dataset_type == "math500":
+       output_len = 1024
     request = InputRequest(
         prompt, prompt_len, output, max_output_length or output_len, sample_idx
     )

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -439,7 +439,7 @@ def filter_dataset(
       continue
     # TODO: should pass in the actual solution length instead of hardcode.
     if dataset_type == "math500":
-       output_len = 1024
+        output_len = 1024
     request = InputRequest(
         prompt, prompt_len, output, max_output_length or output_len, sample_idx
     )


### PR DESCRIPTION
Temporarily lifts the output length constraints for Math 500 dataset. Added a TODO for the fix that supports filter based on output size. This temp solutions favors accuracy over performance.