### PR TITLE
Fix the Math benchmark issues.

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -364,7 +364,9 @@ def load_math500_dataset(dataset_path: str) -> list[tuple[Any, Any]]:
   abs_path = os.path.abspath(dataset_path)
   with open(abs_path, "r", encoding="utf-8") as f:
     dataset = json.load(f)
-  return [(data["problem"], (data["solution"], data["answer"])) for data in dataset]
+  return [
+      (data["problem"], (data["solution"], data["answer"])) for data in dataset
+  ]
 
 
 def tokenize_dataset(
@@ -414,7 +416,9 @@ def filter_dataset(
     max_output_multiplier: int = 0,
 ) -> list[InputRequest]:
   if max_output_length != 0:
-    print(f"In InputRequest, pass in actual max_output_length: {max_output_length} for each sample")
+    print(
+        f"In InputRequest, pass in actual max_output_length: {max_output_length} for each sample"
+    )
   else:
     print(
         f"In InputRequest, pass in max_output_length: {max_output_length} for"
@@ -439,15 +443,18 @@ def filter_dataset(
       # is too short.
       # Math results could be really short though.
       continue
-    if prompt_len > max_input_length or prompt_len + output_len > max_target_length:
+    if (
+        prompt_len > max_input_length
+        or prompt_len + output_len > max_target_length
+    ):
       # Prune too long sequences.
       continue
     if dataset_type == "math500":
-      max_output_len = max_output_length or output_len * max_output_multiplier 
+      max_output_len = max_output_length or output_len * max_output_multiplier
     else:
       max_output_len = max_output_length or output_len
     request = InputRequest(
-        prompt, prompt_len, output, max_output_len , sample_idx
+        prompt, prompt_len, output, max_output_len, sample_idx
     )
     filtered_dataset.append(request)
 
@@ -500,7 +507,13 @@ def sample_requests(
   tokenized_dataset = tokenize_dataset(sampled_dataset, tokenizer)
 
   input_requests = filter_dataset(
-      tokenized_dataset, dataset_type, max_output_length, run_mmlu_dataset, max_input_length, max_target_length, max_output_multiplier
+      tokenized_dataset,
+      dataset_type,
+      max_output_length,
+      run_mmlu_dataset,
+      max_input_length,
+      max_target_length,
+      max_output_multiplier,
   )
 
   # Sample the requests.

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -728,7 +728,6 @@ async def benchmark(
   if pbar is not None:
     pbar.close()
 
-  # import pdb; pdb.set_trace()
   # Compute metrics
   output_metrics = {}
   if not is_warmup:

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -1061,7 +1061,7 @@ def main(args: argparse.Namespace):
     if args.run_mmlu_dataset:
       eval_json = eval_accuracy_mmlu(output)
     else:
-      eval_json = eval_accuracy(output, args.dataset_type[:4])
+      eval_json = eval_accuracy(output, args.dataset[:4])
 
   # Save config and results to json
   if args.save_result:

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -373,15 +373,6 @@ def tokenize_dataset(
     dataset: list[tuple[Any, Any, Any]],
     tokenizer: Any,
 ) -> list[tuple[str, Any, str, int, int, int]]:
-
-  n = len(dataset)
-
-  prompts = []
-  outputs = []
-  indices = []
-  output_lens = []
-  prompt_token_ids = []
-  outputs_token_ids = []
   tokenized_dataset = []
 
   for prompt, output, idx in dataset:
@@ -415,15 +406,10 @@ def filter_dataset(
     max_target_length: int = 0,
     max_output_multiplier: int = 0,
 ) -> list[InputRequest]:
-  if max_output_length != 0:
-    print(
-        f"In InputRequest, pass in actual max_output_length: {max_output_length} for each sample"
-    )
-  else:
-    print(
-        f"In InputRequest, pass in max_output_length: {max_output_length} for"
-        " each sample"
-    )
+  print(
+      f"In InputRequest, pass in max_output_length: {max_output_length} for"
+      " each sample"
+  )
 
   # Filter out too long sequences.
   filtered_dataset: list[InputRequest] = []
@@ -932,7 +918,7 @@ def parse_args() -> argparse.Namespace:
       type=int,
       default=2,
       help=(
-          "The multiplier applied to the reference output length. The generated "
+          "The multiplier applied to the reference output length. The generated"
           " output might be longer than the reference outputs. We apply this "
           " multiplier for finer grained control. "
       ),

--- a/benchmarks/eval_accuracy.py
+++ b/benchmarks/eval_accuracy.py
@@ -23,30 +23,30 @@ import numpy as np
 
 
 def extract_boxed_answers(text):
-    pieces = text.split('boxed{')
-    if len(pieces) == 1:
-        return ''
-    piece = pieces[1]
-    n = 0
-    for i in range(len(piece)):
-        if piece[i] == '{':
-            n += 1
-        elif piece[i] == '}':
-            n -= 1
-            if n < 0:
-                if i + 1 < len(piece) and piece[i + 1] == '%':
-                    return piece[: i + 1]
-                else:
-                    return piece[:i]
-    return ''
+  pieces = text.split("boxed{")
+  if len(pieces) == 1:
+    return ""
+  piece = pieces[1]
+  n = 0
+  for i in range(len(piece)):
+    if piece[i] == "{":
+      n += 1
+    elif piece[i] == "}":
+      n -= 1
+      if n < 0:
+        if i + 1 < len(piece) and piece[i + 1] == "%":
+          return piece[: i + 1]
+        else:
+          return piece[:i]
+  return ""
 
 
 def replace_space_answers(text):
-    return text.replace(" ", "")
+  return text.replace(" ", "")
 
 
 def special_handling(text):
-    return text.replace("\\dfrac", "\\frac")
+  return text.replace("\\dfrac", "\\frac")
 
 
 def postprocess_text(preds, targets):

--- a/benchmarks/eval_accuracy.py
+++ b/benchmarks/eval_accuracy.py
@@ -22,6 +22,33 @@ import json
 import numpy as np
 
 
+def extract_boxed_answers(text):
+    pieces = text.split('boxed{')
+    if len(pieces) == 1:
+        return ''
+    piece = pieces[1]
+    n = 0
+    for i in range(len(piece)):
+        if piece[i] == '{':
+            n += 1
+        elif piece[i] == '}':
+            n -= 1
+            if n < 0:
+                if i + 1 < len(piece) and piece[i + 1] == '%':
+                    return piece[: i + 1]
+                else:
+                    return piece[:i]
+    return ''
+
+
+def replace_space_answers(text):
+    return text.replace(" ", "")
+
+
+def special_handling(text):
+    return text.replace("\\dfrac", "\\frac")
+
+
 def postprocess_text(preds, targets):
   preds = [pred.strip() for pred in preds]
   targets = [target.strip() for target in targets]
@@ -39,15 +66,20 @@ def eval_accuracy(request_outputs_dict, match_type):
   for output in request_outputs_dict:
     preds.append(output["generated_text"])
     targets.append(output["original_output"])
-  preds, targets = postprocess_text(preds, targets)
+  if match_type != "math":
+    preds, targets = postprocess_text(preds, targets)
 
   if match_type == "math":
+
     correct_ans = 0
     wrong_ans = 0
     for p, t in zip(preds, targets):
-      # We claim success if the generated text contains the correct results at
-      # the end and matches literally.
-      if p.endswith(t):
+      import pdb; pdb.set_trace()
+      ans = extract_boxed_answers(p)
+      ans = replace_space_answers(ans)
+      ans = special_handling(ans)
+      tt = replace_space_answers(t)
+      if tt == ans:
         correct_ans += 1
         continue
       wrong_ans += 1

--- a/benchmarks/eval_accuracy.py
+++ b/benchmarks/eval_accuracy.py
@@ -74,7 +74,6 @@ def eval_accuracy(request_outputs_dict, match_type):
     correct_ans = 0
     wrong_ans = 0
     for p, t in zip(preds, targets):
-      import pdb; pdb.set_trace()
       ans = extract_boxed_answers(p)
       ans = replace_space_answers(ans)
       ans = special_handling(ans)


### PR DESCRIPTION
Add the solution fields to the dataset to calculated the correct expected output length. Add 2 more options

max-target-length: the max prompt + output length, the value should also be set to MaxText

max-output-multiplier: the generated outputs could be longer than the reference answer, we multiply reference output length with with this multiplier to give models more freedom to the generated solution

max-input-length: the max context length, should also be set in MaxText. It was hard coded before.
