### PR TITLE
[cleanup] Refactor prefill functions

### DIFF
--- a/experimental/jax/inference/runtime/model_executor.py
+++ b/experimental/jax/inference/runtime/model_executor.py
@@ -26,7 +26,7 @@ from inference.nn import AttentionMetadata, KVCache
 from inference.model import ModelOutput, SamplingParams
 from inference import parallel
 from inference.runtime.batch_scheduler import Schedule, PrefillPagesUpdate
-from inference.runtime.request_type import GenerateState, PrefillRequest, GenerateRequest
+from inference.runtime.request_type import GenerateState, PrefillRequest
 
 ModelForwardFunc = Callable[
     [
@@ -119,9 +119,9 @@ class Executor:
           prefill_request=PrefillRequest(
               id="0",
               unpadded_token_ids=[1],
-              page_indices=dummy_page_indices,
               chunk_idx=0,
               chunk_size=size,
+              page_indices=dummy_page_indices,
               device_token_ids=dummy_padded_tensor,
               device_positions=dummy_padded_tensor,
           ),
@@ -207,9 +207,9 @@ class Executor:
           prefill_request=PrefillRequest(
               id="0",
               unpadded_token_ids=[1],
-              page_indices=dummy_prefill_page_indices,
               chunk_idx=0,
               chunk_size=prefill_chunk_size,
+              page_indices=dummy_prefill_page_indices,
               device_token_ids=dummy_padded_prompt_tensor,
               device_positions=dummy_padded_prompt_tensor,
           ),

--- a/experimental/jax/inference/runtime/request_type.py
+++ b/experimental/jax/inference/runtime/request_type.py
@@ -63,10 +63,9 @@ class PrefillRequest:
 
   id: str
   unpadded_token_ids: list[int]
-  page_indices: list[int]
   chunk_idx: int
   chunk_size: int
-
+  page_indices: list[int]
   device_token_ids: jax.Array
   device_positions: jax.Array
 


### PR DESCRIPTION
$ python experimental/jax/inference/entrypoint/mini_offline_benchmarking.py

Engine total run time: 1421.40 seconds
Benchmarking result:
  Total requests: 24000
  Total input tokens: 5311936
  Total output tokens: 7016688
  Input token thruput:  3737.14 tokens/sec
  Output token thruput:  4936.50 tokens/sec