### PR TITLE
Add long context dataset benchmark support

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -279,6 +279,21 @@ def load_openorca_dataset_pkl(
   return [(prompt, output) for prompt, output in zip(prompts, outputs)]
 
 
+def load_longcontext_dataset_pkl(
+    dataset_path: str,
+) -> list[tuple[Any, Any]]:
+  assert os.path.isfile(dataset_path)
+
+  # read pickle file
+  data = pandas.read_pickle(dataset_path)
+
+  samples = []
+  for _, row in data.iterrows():
+    samples.append((row["input"], row["ref_output"]))
+
+  return samples
+
+
 def load_mmlu_dataset_csv(dataset_path: str) -> tuple[Any, dict[str, str]]:
   assert dataset_path != ""
   dataset = []
@@ -837,7 +852,14 @@ def parse_args() -> argparse.Namespace:
       "--dataset",
       type=str,
       default="test",
-      choices=["test", "sharegpt", "openorca", "mmlu", "math500"],
+      choices=[
+          "test",
+          "sharegpt",
+          "openorca",
+          "mmlu",
+          "math500",
+          "longcontext",
+      ],
       help="The dataset name.",
   )
   parser.add_argument("--dataset-path", type=str, help="Path to the dataset.")
@@ -1055,6 +1077,10 @@ def main(args: argparse.Namespace):
       )
     elif args.dataset == "math500":
       dataset = load_math500_dataset(
+          args.dataset_path,
+      )
+    elif args.dataset == "longcontext":
+      dataset = load_longcontext_dataset_pkl(
           args.dataset_path,
       )
     else:

--- a/jetstream/core/orchestrator.py
+++ b/jetstream/core/orchestrator.py
@@ -628,7 +628,7 @@ class Driver:
                   is_bos,
                   prefill_engine.max_prefill_length,
                   prefill_engine.use_chunked_prefill,
-                  prefill_engine.chunk_size,
+                  prefill_engine.prefill_chunk_size,
               )
           )
           prefill_result = None
@@ -649,7 +649,7 @@ class Driver:
             t_l_array = jnp.expand_dims(
                 jnp.arange(
                     0,
-                    chunk_num * prefill_engine.chunk_size
+                    chunk_num * prefill_engine.prefill_chunk_size
                     + true_lengths_of_chunks[chunk_num],
                 ),
                 1,

--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -446,11 +446,6 @@ class JetStreamEngine(Engine):
     return self._downstream_engine.use_chunked_prefill
 
   @property
-  def chunk_size(self) -> bool:
-    """Maximum prefill length."""
-    return self._downstream_engine.prefill_chunk_size
-
-  @property
   def prefill_chunk_size(self) -> int:
     """Maximum prefill length."""
     return self._downstream_engine.prefill_chunk_size

--- a/jetstream/engine/mock_engine.py
+++ b/jetstream/engine/mock_engine.py
@@ -501,11 +501,6 @@ class TestEngine(engine_api.Engine):
     return self._use_chunked_prefill
 
   @property
-  def chunk_size(self) -> bool:
-    """Maximum prefill length."""
-    return 2
-
-  @property
   def prefill_chunk_size(self) -> int:
     """Maximum prefill length."""
     return 64

--- a/jetstream/tests/core/test_orchestrator.py
+++ b/jetstream/tests/core/test_orchestrator.py
@@ -108,9 +108,9 @@ class OrchestratorTest(unittest.IsolatedAsyncioTestCase):
         max_tokens=3,
     )
     iterator = client.Decode(request)
-    # chr of [266, 332, 415].
-    expected_text = ["B", "R", "g", ""]
-    expected_token_ids = [66, 82, 103, None]
+    # chr of [135, 168, 210].
+    expected_text = ["\x87", "¨", "Ò", ""]
+    expected_token_ids = [135, 168, 210, None]
     counter = 0
     async for resp in iterator:
       output_text = resp.stream_content.samples[0].text


### PR DESCRIPTION
* To download the dataset:
```
sudo -v ; curl https://rclone.org/install.sh | sudo bash
rclone config create mlc-inference s3 provider=Cloudflare access_key_id=f65ba5eef400db161ea49967de89f47b secret_access_key=fbea333914c292b854f14d3fe232bad6c5407bf0ab1bebf78833c2b359bdfd2b endpoint=https://c2686074cb2caf5cbaf6d134bdba8b47.r2.cloudflarestorage.com
rclone copy mlc-inference:mlcommons-inference-wg-public/llama3.1_405b/mlperf_llama3.1_405b_dataset_8313_processed_fp16_eval.pkl ./ -P
```
* To benchmark with the dataset: 
```
python benchmarks/benchmark_serving.py   --tokenizer ~/maxtext/assets/tokenizer.llama2  --warmup-mode sampled   --save-result   --save-request-outputs   --request-outputs-file-path outputs.json   --num-prompts 1000   --max-output-length {MAX_OUTPUT_LENGTH} --max-input-length {MAX_INPUT_LENGTH}  --dataset longcontext --dataset-path {DATASET_PATH} --max-target-length {MAX_TARGET_LENGTH}  --run-eval true
```