### PR TITLE
model_ckpt_conversion: use python module, enable gcloud checkpoint downloading

### DIFF
--- a/jetstream/tools/maxtext/model_ckpt_conversion.sh
+++ b/jetstream/tools/maxtext/model_ckpt_conversion.sh
@@ -65,11 +65,11 @@ else
     pip install torch --index-url https://download.pytorch.org/whl/cpu
     # llama_or_mistral_ckpt.py requires local path, so we need to copy the checkpoint from CHKPT_BUCKET to local.
     tmp_ckpt_path="/tmp/"
-    #gcloud storage cp -r ${CHKPT_BUCKET} ${tmp_ckpt_path}
+    gcloud storage cp -r ${CHKPT_BUCKET} ${tmp_ckpt_path}
 
     path_parts=(${CHKPT_BUCKET//\// })
     directory_substring=${path_parts[-1]}
-    CONVERT_CKPT_SCRIPT="llama_or_mistral_ckpt.py"
+    CONVERT_CKPT_SCRIPT="llama_or_mistral_ckpt"
 
     if [[ ! -z "${LORA_INPUT_ADAPTERS_PATH}" ]]; then
 	lora_local_path="/tmp/"


### PR DESCRIPTION
1. https://github.com/AI-Hypercomputer/JetStream/commit/cb86ae263e703c43948daa25ba20367a8fd0368a seems to have missed `llama_or_mistral_ckpt`.

2. GCS copying was commented out in https://github.com/AI-Hypercomputer/JetStream/commit/082c0ac526e50d8f732a083ed43920590d7ffd22. I'm guessing this was unintended.