### PR TITLE
feat: Add prefix cache benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -75,6 +75,7 @@ python benchmark_serving.py \
 ```
 
 ## Benchmark with openorca dataset (openorca is used by MLPerf inference for LLaMA2 models)
+
 ```
 python JetStream/benchmarks/benchmark_serving.py   \
 --tokenizer ~/maxtext/assets/tokenizer.llama2  \
@@ -93,6 +94,7 @@ python JetStream/benchmarks/benchmark_serving.py   \
 The benchmark has better performance if it first conducts a warmup of the JetStream server. We currently support `sampled` and `full` warmup modes. `full` mode would warmup up the JetStream server with all the input requests. `sampled` mode would warmup up the JetStream server with a sampling of the input requests across different bucket sizes of input lengths.
 
 Example to run benchmark with `full` warmup mode:
+
 ```
 python JetStream/benchmarks/benchmark_serving.py   \
 --tokenizer ~/maxtext/assets/tokenizer.llama2  \
@@ -115,7 +117,25 @@ python eval_accuracy.py outputs.json
 ```
 
 With openorca dataset and llama2-chat models (used by MLPerf), here are the reference accuracy numbers:
+
 ```
 llama2-7b-chat {'rouge1': 42.0706, 'rouge2': 19.8021, 'rougeL': 26.8474, 'rougeLsum': 39.5952, 'gen_len': 1146679, 'gen_num': 998}
 llama2-70b-chat {'rouge1': 44.4312, 'rouge2': 22.0352, 'rougeL': 28.6162}
-``` 
+```
+
+## Benchmark prefix cache
+
+Benchmark with mock input requests that share common prefix. Use to test prefix caching.
+
+All prompts length is `max-input-length`, and share common prefix mean at length `--prefix-cache-test-common-len` with normal distribution.
+
+```
+python JetStream/benchmarks/benchmark_serving.py \
+--tokenizer prefix_cache_test \
+--dataset prefix_cache_test
+--warmup-mode full \
+--num-prompts 100 \
+--max-input-length 16000 \
+--prefix-cache-test-common-len 9000\
+--max-output-length 50 \
+```

--- a/benchmarks/benchmark_prefix_cache.sh
+++ b/benchmarks/benchmark_prefix_cache.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+NUM_PROMPTS=${NUM_PROMPTS:-100}
+MAX_OUTPUT_LENGTH=${MAX_OUTPUT_LENGTH:-50}
+
+# Test combination from lengths and common prefix lengths.
+# The length should be shorter than max_input_length minus 1 for bos.
+BENCHMARK_PROMPT_LENGTHS=${BENCHMARK_PROMPT_LENGTHS:-8000,16000}
+BENCHMARK_PROMPT_COMMON_PREFIX_LENGTHS=${BENCHMARK_PROMPT_COMMON_PREFIX_LENGTHS:-4000,6000,8000,10000,12000,14000,16000}
+
+benchmark_serving_with_prefix_cache() {
+  echo "Starting prefix cache benchmark..."
+  echo "Benchmark serving script: ${BENCHMARK_SERVING_SCRIPT_PATH}"
+  echo "Prompt lengths to test: ${BENCHMARK_PROMPT_LENGTHS}"
+  echo "Common prefix lengths to test: ${BENCHMARK_PROMPT_COMMON_PREFIX_LENGTHS}"
+  echo "Number of prompts per run: ${NUM_PROMPTS}"
+  echo "Max output length per prompt: ${MAX_OUTPUT_LENGTH}"
+  echo "Base output directory for results: ${OUTPUTS_DIR_BASE}"
+  echo "Warmup mode: ${WARMUP_MODE}"
+
+  # Convert comma-separated strings to arrays for iteration
+  IFS=',' read -r -a prompt_lengths_arr <<< "$BENCHMARK_PROMPT_LENGTHS"
+  IFS=',' read -r -a common_prefix_lengths_arr <<< "$BENCHMARK_PROMPT_COMMON_PREFIX_LENGTHS"
+
+  for prompt_len in "${prompt_lengths_arr[@]}"; do
+    for common_len in "${common_prefix_lengths_arr[@]}"; do
+      if [ "${common_len}" -gt "${prompt_len}" ]; then
+        echo "Skipping: Common prefix length ${common_len} is greater than prompt length ${prompt_len}."
+        continue
+      fi
+
+      echo "----------------------------------------------------------------------"
+      echo "Running benchmark: Prompt Length=${prompt_len}, Common Prefix Length=${common_len}"
+      echo "----------------------------------------------------------------------"
+      echo "Warm up twice"
+      echo "----------------------------------------------------------------------"
+      
+      # With warmup-mode full, it will run twice
+      python3 ./benchmark_serving.py \
+        --tokenizer "prefix_cache_test" \
+        --dataset "prefix_cache_test" \
+        --num-prompts 10 \
+        --max-output-length "${MAX_OUTPUT_LENGTH}" \
+        --warmup-mode "full" \
+        --max-input-length "${prompt_len}" \
+        --prefix-cache-test-common-len "${common_len}"
+
+      echo "Warm up done"
+      echo "----------------------------------------------------------------------"
+
+      python3 ./benchmark_serving.py \
+        --tokenizer "prefix_cache_test" \
+        --dataset "prefix_cache_test" \
+        --num-prompts "${NUM_PROMPTS}" \
+        --max-output-length "${MAX_OUTPUT_LENGTH}" \
+        --warmup-mode "none" \
+        --max-input-length "${prompt_len}" \
+        --prefix-cache-test-common-len "${common_len}"
+
+      echo "Benchmark finished for Prompt Length=${prompt_len}, Common Prefix Length=${common_len}"
+      echo "----------------------------------------------------------------------"
+      echo
+    done
+  done
+  echo "All benchmark runs completed."
+}
+
+main() {
+  benchmark_serving_with_prefix_cache
+  echo "Script finished."
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
This commit introduces a new benchmark to test the performance of prefix caching in JetStream.

The benchmark (`benchmark_prefix_cache.sh`) allows testing with various prompt lengths and common prefix lengths. It utilizes a new mock dataset generated by `load_mock_prefix_cache_test_input_requests` in `benchmark_serving.py`, which creates prompts sharing common prefixes of varying lengths based on a normal distribution.

Key changes include:
- New script `benchmarks/benchmark_prefix_cache.sh` to orchestrate prefix cache benchmark runs.
- Added `PrefixCacheTestTokenizer` for simple character-to-ordinal tokenization, suitable for controlled prefix testing.
- Implemented `load_mock_prefix_cache_test_input_requests` in `benchmark_serving.py` to generate test data with shared prefixes.
- Added `prefix_cache_test` as a dataset option and `--prefix-cache-test-common-len` argument to `benchmark_serving.py`.
- Updated `benchmarks/README.md` with instructions on how to run the new prefix cache benchmark.