### PR TITLE
Add gcloud setup same as Maxtext

### DIFF
--- a/experimental/jetstream-maxtext-stable-stack/Dockerfile
+++ b/experimental/jetstream-maxtext-stable-stack/Dockerfile
@@ -64,6 +64,16 @@ RUN apt-get update \
 
 RUN python3 -m pip install --upgrade pip
 
+# Add the Google Cloud SDK package repository
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+# Install the Google Cloud SDK
+RUN apt-get update && apt-get install -y google-cloud-sdk
+
+# Set environment variables for Google Cloud SDK
+ENV PATH="/usr/local/google-cloud-sdk/bin:${PATH}"
+
 # Install MaxText package
 COPY --from=maxtext_cloner /src .
 RUN cd maxtext && bash setup.sh


### PR DESCRIPTION
gcloud setup has been failing in Dockerfile. 

Tried previously - 
pip install
gcloud-cli-sdk install

In the PR -
Added changes similar to Maxtext- 
https://github.com/AI-Hypercomputer/maxtext/blob/4ac910d3435c75ce3f922459c71181068d1d5e4e/maxtext_gpu_dependencies.Dockerfile#L14C1-L22C51

