### PR TITLE
log prob should be a pytree node

### DIFF
--- a/jetstream/engine/engine_api.py
+++ b/jetstream/engine/engine_api.py
@@ -94,7 +94,6 @@ class ResultTokens(abc.ABC):
   )
   # log probabilities of the tokens. Shape: [batch, tokens]
   log_prob: Union[jax.Array, np.ndarray] = struct.field(
-      pytree_node=False,
       default=None,
   )
 


### PR DESCRIPTION
Bug Fix: register ResultTokens' `log_prob` as a pytree node.  