### PR TITLE
Fix 404ing URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 > [!WARNING]
-> **Notice of Archival:** In an effort to streamline TPU inference efforts in open source, we have migrated core functionality in Jetstream to the new [tpu-inference](tpu.vllm.ai) repository. For this reason, we will be archiving Jetstream on February 1st 2026. Please note, archival does not mean deletion! Users will still be able to fork and clone Jetstream, we are simply shifting the repository to "read-only". To get Jetstream features and so much more, please check out [tpu.vllm.ai](tpu.vllm.ai).
+> **Notice of Archival:** In an effort to streamline TPU inference efforts in open source, we have migrated core functionality in Jetstream to the new [tpu-inference](https://tpu.vllm.ai) repository. For this reason, we will be archiving Jetstream on February 1st 2026. Please note, archival does not mean deletion! Users will still be able to fork and clone Jetstream, we are simply shifting the repository to "read-only". To get Jetstream features and so much more, please check out [tpu.vllm.ai](https://tpu.vllm.ai).
 
 # JetStream is a throughput and memory optimized engine for LLM inference on XLA devices.
 


### PR DESCRIPTION
The links in the README.md in the "Notice of Archival" 404.
See existing README.md: https://github.com/AI-Hypercomputer/JetStream/blob/acd4f5ad50ed2fb38e0e5bd7defd81e34a62706c/README.md
