### PR TITLE
Fix link to tpu-inference repo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 > [!WARNING]
-> **Notice of Archival:** In an effort to streamline TPU inference efforts in open source, we have migrated core functionality in Jetstream to the new [tpu-inference](tpu.vllm.ai) repository. For this reason, we will be archiving Jetstream on February 1st 2026. Please note, archival does not mean deletion! Users will still be able to fork and clone Jetstream, we are simply shifting the repository to "read-only". To get Jetstream features and so much more, please check out [tpu.vllm.ai](tpu.vllm.ai).
+> **Notice of Archival:** In an effort to streamline TPU inference efforts in open source, we have migrated core functionality in Jetstream to the new [tpu-inference](https://tpu.vllm.ai) repository. For this reason, we will be archiving Jetstream on February 1st 2026. Please note, archival does not mean deletion! Users will still be able to fork and clone Jetstream, we are simply shifting the repository to "read-only". To get Jetstream features and so much more, please check out [tpu.vllm.ai](https://tpu.vllm.ai).
 
 # JetStream is a throughput and memory optimized engine for LLM inference on XLA devices.
 


### PR DESCRIPTION
Add missing `https://` protocol to the URL, without which, it is treated as a local file, which doesn't exist in this repo.